### PR TITLE
Pkg 4115 v12.4 initial

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,3 +9,6 @@ cross_target_platform:
   - linux-ppc64le  # [linux]
   - linux-aarch64  # [linux]
   - win-64         # [win]
+conda_glibc_ver:
+  - 2.17          # [not aarch64]
+  - 2.26          # [aarch64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
-c_compiler_version:        # [linux]
-  - 12                     # [linux]
-cxx_compiler_version:      # [linux]
-  - 12                     # [linux]
+# c_compiler_version:        # [linux]
+#   - 12                     # [linux]
+# cxx_compiler_version:      # [linux]
+#   - 12                     # [linux]
 arm_variant_type:          # [aarch64]
   - sbsa                   # [aarch64]
 cross_target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ outputs:
       - etc/conda/deactivate.d/~cuda-nvcc_deactivate.bat  # [win]
     requirements:
       host:
-        - sysroot_{{ cross_target_platform }} 2.17.*  # [linux]
+        - sysroot_{{ cross_target_platform }} {{ conda_glibc_ver }}.*  # [linux]
       run:
         - cuda-nvcc-dev_{{ cross_target_platform }} {{ version }}.*
         - cuda-cudart-dev_{{ cross_target_platform }} {{ cuda_version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   skip: true  # [osx or (linux and s390x)]
-  skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
+  skip: true  # [target_platform != cross_target_platform]
 
 outputs:
   - name: cuda-nvcc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx]
+  skip: true  # [osx or (linux and s390x)]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,9 @@ outputs:
         - CMakeLists.txt
         - run_cmake_cuda_tests.sh  # [linux]
       commands:
+        # cmake has trouble finding ar on linux-aarch64; so this needs to be added
+        # compared to conda-forge. NB conda-forge isn't building this on linux-aarch64 currently.
+        - if [ ! -f "${PREFIX}/bin/ar" ]; then ln -s "${AR}" "${PREFIX}/bin/ar"; fi # [linux and aarch64]
         - nvcc --version
         - $CXX --verbose ${CXXFLAGS} -lcuda -lcudart_static test.cpp  # [linux]
         - cl /Tp test.cpp /link /LIBPATH:"%CONDA_PREFIX%\Library\lib" cudart_static.lib /out:test_nvcc.exe  # [win]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4584](https://anaconda.atlassian.net/browse/PKG-4584)

### Explanation of changes:

- Fifth package of CUDA 12.4 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Changes made to adjust feedstocks for differences between conda-forge and defaults. Please see commit messages for description of changes.
- There's an [open issue](https://github.com/conda-forge/cuda-nvcc-feedstock/issues/40) upstream but I suggest we don't wait on it and catch it with the next update.


[PKG-4584]: https://anaconda.atlassian.net/browse/PKG-4584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ