### PR TITLE
cuda-nvcc v13.1.115

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-nvcc-split" %}
-{% set version = "13.1.80" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set exists = "which" %}  # [not win]
 {% set exists = "where" %}  # [win]
@@ -19,7 +19,7 @@ source:
 {% endif %}
 
 build:
-  number: {{ number }}
+  number: 0
   skip: true  # [osx or ppc64le]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,13 @@ source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/LICENSE.txt
   sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
-{% set number = 4 %}
+{% set number = 0 %}
 {% if arm_variant_target == "sbsa" %}
 {% set number = number + 100 %}
 {% endif %}
 
 build:
-  number: 0
+  number: {{ number }}
   skip: true  # [osx or ppc64le]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-nvcc-split" %}
-{% set version = "13.0.88" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.80" %}
+{% set cuda_version = "13.1" %}
 {% set exists = "which" %}  # [not win]
 {% set exists = "where" %}  # [win]
 
@@ -19,7 +19,7 @@ source:
 {% endif %}
 
 build:
-  number: {{ number }}
+  number: 0
   skip: true  # [osx or ppc64le]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
   script_env:


### PR DESCRIPTION
cuda-nvcc 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12030](https://anaconda.atlassian.net/browse/PKG-12030) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12030]: https://anaconda.atlassian.net/browse/PKG-12030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ