### PR TITLE
cuda-nvcc v13.0.88 b1

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      ? linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64
-      : CONFIG: linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64
+      ? linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75__h31c4d59b
+      : CONFIG: linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75__h31c4d59b
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      ? linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualarm_variant_targetNonecross_target_platformlinux-64
-      : CONFIG: linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualarm_variant_targetNonecross_target_platformlinux-64
+      ? linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75_-gencode_arch=com_h6671ea13
+      : CONFIG: linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75_-gencode_arch=com_h6671ea13
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      ? linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64
-      : CONFIG: linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64
+      ? linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=s_h25bbfdeb
+      : CONFIG: linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=s_h25bbfdeb
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75__h31c4d59b.yaml
+++ b/.ci_support/linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75__h31c4d59b.yaml
@@ -1,5 +1,11 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtual
+DEFAULT_NVCC_GENCODE:
+- -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode
+  arch=compute_86,code=sm_86 -gencode arch=compute_87,code=sm_87 -gencode arch=compute_89,code=sm_89
+  -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode
+  arch=compute_103f,code=sm_103f -gencode arch=compute_110,code=sm_110 -gencode arch=compute_120a,code=sm_120a
+  -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121
 arm_variant_target:
 - sbsa
 c_compiler:
@@ -23,10 +29,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
+  - DEFAULT_NVCC_GENCODE
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75_-gencode_arch=com_h6671ea13.yaml
+++ b/.ci_support/linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75_-gencode_arch=com_h6671ea13.yaml
@@ -1,5 +1,11 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual
+DEFAULT_NVCC_GENCODE:
+- -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode
+  arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a
+  -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f
+  -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f
+  -gencode arch=compute_121,code=compute_121
 arm_variant_target:
 - None
 c_compiler:
@@ -28,5 +34,6 @@ zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
+  - DEFAULT_NVCC_GENCODE
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=s_h25bbfdeb.yaml
+++ b/.ci_support/linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=s_h25bbfdeb.yaml
@@ -1,5 +1,11 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtual
+DEFAULT_NVCC_GENCODE:
+- -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode
+  arch=compute_86,code=sm_86 -gencode arch=compute_87,code=sm_87 -gencode arch=compute_89,code=sm_89
+  -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode
+  arch=compute_103f,code=sm_103f -gencode arch=compute_110,code=sm_110 -gencode arch=compute_120a,code=sm_120a
+  -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121
 arm_variant_target:
 - sbsa
 c_compiler:
@@ -23,10 +29,11 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
+  - DEFAULT_NVCC_GENCODE
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,11 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual
+DEFAULT_NVCC_GENCODE:
+- -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode
+  arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a
+  -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f
+  -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f
+  -gencode arch=compute_121,code=compute_121
 arm_variant_target:
 - None
 c_compiler:
@@ -18,3 +24,4 @@ zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
+  - DEFAULT_NVCC_GENCODE

--- a/README.md
+++ b/README.md
@@ -92,24 +92,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64</td>
+              <td>linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75__h31c4d59b</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19219&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-nvcc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-nvcc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75__h31c4d59b" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualarm_variant_targetNonecross_target_platformlinux-64</td>
+              <td>linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75_-gencode_arch=com_h6671ea13</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19219&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-nvcc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualarm_variant_targetNonecross_target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-nvcc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_DEFAULT_CUDAARCHS75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=sm_75_-gencode_arch=com_h6671ea13" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64</td>
+              <td>linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=s_h25bbfdeb</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19219&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-nvcc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualarm_variant_targetsbsacross_target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-nvcc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_DEFAULT_CUDAARCHS75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtualDEFAULT_NVCC_GENCODE-gencode_arch=compute_75code=s_h25bbfdeb" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -17,4 +17,8 @@ if "%CONDA_BUILD%" == "1" (
         set "CUDAARCHS=@default_cudaarchs@"
         set "CUDAARCHS_BACKUP=UNSET"
     )
+    if not defined NVCC_GENCODE (
+        set "NVCC_GENCODE=@default_nvcc_gencode@"
+        set "NVCC_GENCODE_BACKUP=UNSET"
+    )
 )

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -76,6 +76,12 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
         export CUDAARCHS_BACKUP="UNSET"
     fi
 
+    if [[ ! -v NVCC_GENCODE ]]
+    then
+        export NVCC_GENCODE="@default_nvcc_gencode@"
+        export NVCC_GENCODE_BACKUP="UNSET"
+    fi
+
 fi
 
 # Exit with unclean status if there was an error

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,7 @@ setlocal enableextensions enabledelayedexpansion
 if errorlevel 1 exit 1
 
 sed -e "s/@default_cudaarchs@/%DEFAULT_CUDAARCHS%/g" ^
+    -e "s/@default_nvcc_gencode@/%DEFAULT_NVCC_GENCODE%/g" ^
     %RECIPE_DIR%\activate.bat > %RECIPE_DIR%\activate-replaced.bat
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,7 @@ do
     sed -e "s/@cross_target_platform@/$cross_target_platform/g" \
         -e "s/@arm_variant_target@/$arm_variant_target/g" \
         -e "s/@default_cudaarchs@/$DEFAULT_CUDAARCHS/g" \
+        -e "s/@default_nvcc_gencode@/$DEFAULT_NVCC_GENCODE/g" \
     "${RECIPE_DIR}/${CHANGE}.sh" > "${PREFIX}/etc/conda/${CHANGE}.d/~cuda-nvcc_${CHANGE}.sh"
 done
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -18,8 +18,13 @@ DEFAULT_CUDAARCHS:
   - "75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"
   # aarch64 has more targets than x86 because Tegra devices are sbsa aarch64 only
   - "75-real;80-real;86-real;87-real;89-real;90a-real;100f-real;103f-real;110-real;120a-real;121f-real;121-virtual"  # [linux]
+DEFAULT_NVCC_GENCODE:
+  - "-gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121"
+  # aarch64 has more targets than x86 because Tegra devices are sbsa aarch64 only
+  - "-gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_87,code=sm_87 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f -gencode arch=compute_110,code=sm_110 -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121"  # [linux]
 
 zip_keys:
   - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
+  - DEFAULT_NVCC_GENCODE

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -14,3 +14,8 @@ if "%CUDAARCHS_BACKUP%" == "UNSET" (
     set "CUDAARCHS="
     set "CUDAARCHS_BACKUP="
 )
+
+if "%NVCC_GENCODE_BACKUP%" == "UNSET" (
+    set "NVCC_GENCODE="
+    set "NVCC_GENCODE_BACKUP="
+)

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -22,3 +22,9 @@ then
   unset CUDAARCHS
   unset CUDAARCHS_BACKUP
 fi
+
+if [[ "${NVCC_GENCODE_BACKUP}" == "UNSET" ]]
+then
+  unset NVCC_GENCODE
+  unset NVCC_GENCODE_BACKUP
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ build:
   # We need to reference these variables in the recipe or conda-smithy will prune them from
   # the conda_build_config
     - DEFAULT_CUDAARCHS={{ DEFAULT_CUDAARCHS }}
+    - DEFAULT_NVCC_GENCODE={{ DEFAULT_NVCC_GENCODE }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/LICENSE.txt
   sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
-{% set number = 4 %}
+{% set number = 5 %}
 {% if arm_variant_target == "sbsa" %}
 {% set number = number + 100 %}
 {% endif %}


### PR DESCRIPTION
cuda-nvcc 13.0.88 b1

**Destination channel:** defaults

### Links

- [PKG-12410](https://anaconda.atlassian.net/browse/PKG-12410) 

### Explanation of changes:

- Sync with the CF feedstock `13.0` branch
- Add `NVCC_GENCODE` for `conda-build` environment


[PKG-12410]: https://anaconda.atlassian.net/browse/PKG-12410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ