### PR TITLE
cuda-nvcc v12.9.86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+# - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,31 +1,47 @@
 c_compiler_version:        # [linux]
-  - 12                     # [linux]
+  - 14                     # [linux]
 cxx_compiler_version:      # [linux]
-  - 12                     # [linux]
+  - 14                     # [linux]
 c_compiler:                # [win]
-  - vs2019                 # [win]
+  - vs2022                 # [win]
 cxx_compiler:              # [win]
-  - vs2019                 # [win]
+  - vs2022                 # [win]
+
+# Important change for generating the correct graph on PBP:
+#  * Added 'not (linux and aarch64)' selector to 'None' entry.
+#  * Changed 'linux' selector to 'linux and aarch64' for 'sbsa' entry.
+# These changes would make sure the build graph is correctly generated on PBP.
 arm_variant_target:
-  - None
-  - sbsa                   # [linux]
-  - tegra                  # [linux]
+  - None                   # [not (linux and aarch64)]
+  - sbsa                   # [linux and aarch64]
+#  - tegra                  # [linux and aarch64]
+
+# Important change for generating the correct graph on PBP:
+#  * Changed 'linux' selector to 'linux and x86_64' for 'linux-64' entry.
+#  * Changed 'linux' selector to 'linux and aarch64' for 'linux-aarch64' entry.
+# These changes would make sure the build graph is correctly generated on PBP,
+# and eliminate cross-build targets, such as 'aarch64' build on 'linux64' host.
 cross_target_platform:
   - None           # [not (linux or win)]
-  - linux-64       # [linux]
-  - linux-aarch64  # [linux]
-  - linux-aarch64  # [linux]
+  - linux-64       # [linux and x86_64]
+  - linux-aarch64  # [linux and aarch64]
+#  - linux-aarch64  # [linux and aarch64]
   - win-64         # [win]
+
+# Important change for generating the correct graph on PBP:
+#  * Added 'not (linux and aarch64)' selector to the 1st entry.
+## * Changed 'linux' selector to 'linux and aarch64' on the 2nd entry.
+# These changes would make sure the build graph is correctly generated on PBP.
 # https://docs.nvidia.com/cuda/archive/12.9.1/cuda-compiler-driver-nvcc/#virtual-architecture-feature-list
 # https://docs.nvidia.com/cuda/archive/12.9.1/cuda-compiler-driver-nvcc/#gpu-feature-list
 DEFAULT_CUDAARCHS:
-  - "50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"
-  - "50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"  # [linux]
-  - "87-real;101f-real;101-virtual"  # [linux]
+  - "50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"  # [not (linux and aarch64)]
+  - "50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"  # [linux and aarch64]
+#  - "87-real;101f-real;101-virtual"  # [linux]
 DEFAULT_NVCC_GENCODE:
-  - "-gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121"
-  - "-gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121"  # [linux]
-  - "-gencode arch=compute_87,code=sm_87 -gencode arch=compute_101f,code=sm_101f -gencode arch=compute_101,code=compute_101"  # [linux]
+  - "-gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121"  # [not (linux and aarch64)]
+  - "-gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90a,code=sm_90a -gencode arch=compute_100f,code=sm_100f -gencode arch=compute_103f,code=sm_103f -gencode arch=compute_120a,code=sm_120a -gencode arch=compute_121f,code=sm_121f -gencode arch=compute_121,code=compute_121"  # [linux and aarch64]
+#  - "-gencode arch=compute_87,code=sm_87 -gencode arch=compute_101f,code=sm_101f -gencode arch=compute_101,code=compute_101"  # [linux]
 
 zip_keys:
   - arm_variant_target

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,14 @@ source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/LICENSE.txt
   sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
-{% set number = 6 %}
+{% set number = 0 %}
 {% if arm_variant_target == "sbsa" %}
 {% set number = number + 100 %}
 {% endif %}
 
 build:
   number: {{ number }}
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
   script_env:
   # We need to reference these variables in the recipe or conda-smithy will prune them from
@@ -53,10 +53,12 @@ outputs:
       license_file: LICENSE.txt
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Compiler for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvcc_{{ cross_target_platform }}
     run_exports:
@@ -105,10 +107,12 @@ outputs:
       license_file: LICENSE.txt
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Compiler activation scripts for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-crt
     build:
@@ -126,10 +130,12 @@ outputs:
       license_file: LICENSE.txt
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: CUDA internal headers.
       description: |
         CUDA internal headers.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-nvvm
     build:
@@ -154,20 +160,24 @@ outputs:
       license_file: LICENSE.txt
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Compiler for CUDA applications.
       description: |
         Compiler for CUDA applications.
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Compiler for CUDA applications.
   description: |
     Compiler for CUDA applications.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   feedstock-name: cuda-nvcc

--- a/recipe/run_nvcc_tests.sh
+++ b/recipe/run_nvcc_tests.sh
@@ -36,7 +36,7 @@ cmake --build ./build -v
 
 mkdir -p cmake-tests
 git clone -b v${cmake_version} --depth 1 https://gitlab.kitware.com/cmake/cmake.git cmake-tests
-cmake -S cmake-tests -B cmake-tests/build ${CMAKE_ARGS} -DCMake_TEST_HOST_CMAKE=ON -DCMake_TEST_CUDA=nvcc -G "Ninja"
+cmake -S cmake-tests -B cmake-tests/build ${CMAKE_ARGS} -DCMake_TEST_HOST_CMAKE=ON -DCMake_TEST_CUDA=nvcc -G "Ninja" -DCMake_TEST_CUDA_ARCH=75
 cd cmake-tests/build
 
 # Test exclusion list:
@@ -61,11 +61,22 @@ cd cmake-tests/build
 #   *Toolkit*
 # Failing due to undefined symbol: __libc_dl_error_tsd, version GLIBC_PRIVATE
 #   Cuda.Complex
+#
+# Failing due to error: "__is_nothrow_new_constructible" is not a function or static data member
+#   Cuda.CXXStandardSetTwice
+#   Cuda.MixedStandardLevels1
+#   Cuda.ProperLinkFlags
+#   CudaOnly.EnableStandard
+#   CudaOnly.CircularLinkLine
+#   CudaOnly.SeparateCompilation
+#   CudaOnly.DontResolveDeviceSymbols
+#   CudaOnly.RuntimeControls
+#
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == "0" ]]
 then
     EXTRA_EXCLUDE=
     if [ "${cross_target_platform}" == "linux-ppc64le" ]; then
       EXTRA_EXCLUDE="|CudaOnly.DontResolveDeviceSymbols"
     fi
-    CUDAARCHS="" CUDAHOSTCXX=$CXX ctest -L CUDA --output-on-failure -j $(nproc) -E "(ProperDeviceLibraries|SharedRuntime|ObjectLibrary|WithC|StubRPATH|ArchSpecial|GPUDebugFlag|SeparateCompilationPTX|WithDefs|CUBIN|Fatbin|OptixIR|CUDA_architectures|Toolkit|Cuda.Complex$EXTRA_EXCLUDE)"
+    CUDAARCHS="" CUDAHOSTCXX=$CXX ctest -L CUDA --output-on-failure -j $(nproc) -E "(ProperDeviceLibraries|SharedRuntime|ObjectLibrary|WithC|StubRPATH|ArchSpecial|GPUDebugFlag|SeparateCompilationPTX|WithDefs|CUBIN|Fatbin|OptixIR|CUDA_architectures|Toolkit|Cuda.Complex$EXTRA_EXCLUDE|Cuda.CXXStandardSetTwice|Cuda.MixedStandardLevels1|Cuda.ProperLinkFlags|CudaOnly.EnableStandard|CudaOnly.CircularLinkLine|CudaOnly.SeparateCompilation|CudaOnly.DontResolveDeviceSymbols|CudaOnly.RuntimeControls)"
 fi


### PR DESCRIPTION
cuda-nvcc 12.9.86

**Destination channel:** defaults

### Links

- [PKG-12798](https://anaconda.atlassian.net/browse/PKG-12798) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-nvcc-impl-feedstock/pull/10

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.
### Notes:

- Set minimum GCC version to GCC 14 (for Linux)
- Set minimum Visual Studio version to VS2022 (for Windows)
- Updated list of excluded tests; `CXX_STANDARD` won't apply for some reason, so cannot remove `-std=c++11` argument passed to the `nvcc` during tests
- Copied `-DCMake_TEST_CUDA_ARCH=75` argument from CUDA 13.1's CMake configure argument list. This is about standardization of tests between CUDA 12.x and 13.x. Also, testing a single compute capability should be enough and it shouldn't make any difference in general.


[PKG-12798]: https://anaconda.atlassian.net/browse/PKG-12798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ